### PR TITLE
Prevent skill try calculation from underflowing

### DIFF
--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -183,9 +183,10 @@ uint32_t Vocation::skillBase[SKILL_LAST + 1] = {50, 50, 50, 50, 30, 100, 20};
 
 uint64_t Vocation::getReqSkillTries(uint8_t skill, uint32_t level)
 {
-	if (skill > SKILL_LAST) {
+	if (skill > SKILL_LAST || level <= 10) {
 		return 0;
 	}
+
 	level -= 10;
 
 	std::vector<uint64_t>& skillCache = cacheSkill[skill];
@@ -194,7 +195,7 @@ uint64_t Vocation::getReqSkillTries(uint8_t skill, uint32_t level)
 	}
 
 	uint64_t& tries = skillCache[level];
-	if (level != 0 && tries == 0) {
+	if (tries == 0) {
 		tries = std::max<uint64_t>(1, static_cast<uint64_t>(skillBase[skill] * fast_pow(static_cast<double>(skillMultipliers[skill]), level - 1)));
 	}
 	return tries;
@@ -202,13 +203,17 @@ uint64_t Vocation::getReqSkillTries(uint8_t skill, uint32_t level)
 
 uint64_t Vocation::getReqMana(uint32_t magLevel)
 {
+	if (magLevel == 0) {
+		return 0;
+	}
+
 	std::vector<uint64_t>& manaCache = cacheMana;
 	if (magLevel >= manaCache.size()) {
 		manaCache.resize(static_cast<size_t>(magLevel) + 1, 0);
 	}
 
 	uint64_t& tries = manaCache[magLevel];
-	if (magLevel != 0 && tries == 0) {
+	if (tries == 0) {
 		tries = std::max<uint64_t>(1, static_cast<uint64_t>(1600 * fast_pow(static_cast<double>(manaMultiplier), magLevel - 1)));
 	}
 	return tries;

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -194,7 +194,7 @@ uint64_t Vocation::getReqSkillTries(uint8_t skill, uint32_t level)
 	}
 
 	uint64_t& tries = skillCache[level];
-	if (tries == 0) {
+	if (level != 0 && tries == 0) {
 		tries = std::max<uint64_t>(1, static_cast<uint64_t>(skillBase[skill] * fast_pow(static_cast<double>(skillMultipliers[skill]), level - 1)));
 	}
 	return tries;
@@ -208,7 +208,7 @@ uint64_t Vocation::getReqMana(uint32_t magLevel)
 	}
 
 	uint64_t& tries = manaCache[magLevel];
-	if (tries == 0) {
+	if (magLevel != 0 && tries == 0) {
 		tries = std::max<uint64_t>(1, static_cast<uint64_t>(1600 * fast_pow(static_cast<double>(manaMultiplier), magLevel - 1)));
 	}
 	return tries;


### PR DESCRIPTION
This is a fix to https://github.com/SaiyansKing/optimized_forgottenserver/commit/cb131d51679e62b0ddbaf5e1651b06594310a5e9

If a player has the base skill level (10 for skills, 0 for magic), the calculation would underflow and put an incorrect amount of tries into the cache, making the player unable to ever progress.